### PR TITLE
More helpful message when a phylogeny without node labels is supplied

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,4 @@ Imports:
     ape,
     patchwork
 VignetteBuilder: knitr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/structured_coal.R
+++ b/R/structured_coal.R
@@ -237,7 +237,12 @@ structured_coal.simulate <- function(sampling_times, colours, div_times, div_eve
 #' @export
 preprocess_phylo <- function(phy, order_edges_by_node_label=TRUE){
     stopifnot("phy must be an ape phylogeny"= class(phy) == "phylo")
-    stopifnot("phylogeny must be labeled" = all(!is.na(phy$node.label))&&all(!is.na(phy$tip.label)))
+    stopifnot("Phylogeny must have both node labels and tip labels." =
+                                            !is.null(phy$tip.label) &&
+                                            !is.null(phy$node.label) &&
+                                            all(!is.na(phy$node.label))&&
+                                            all(!is.na(phy$tip.label))
+                                            )
 
     labs <- c(phy$node.label, phy$tip.label)
     nodes <- nodeid(phy, labs)

--- a/man/standard_priors.Rd
+++ b/man/standard_priors.Rd
@@ -6,8 +6,8 @@
 \usage{
 standard_priors(
   expansion_rate = 1,
-  N_mean_log = 4,
-  N_sd_log = 4,
+  N_mean_log = 3,
+  N_sd_log = 3,
   t_mid_rate = 5,
   K_sd_log = 1/2,
   exp_time_nu = 1/2,


### PR DESCRIPTION
run_expansion_inference now fails with a more helpful message if improperly labeled phylogeny is supplied